### PR TITLE
Add `spurt` as a CLI tool on install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ Discussions = "https://github.com/isce-framework/spurt/discussions"
 Homepage = "https://github.com/isce-framework/spurt"
 Issues = "https://github.com/isce-framework/spurt/issues"
 
+# Entry points for the command line interface
+[project.scripts]
+spurt = "spurt.workflows.emcf:__main__"
+
 [tool.black]
 preview = true
 


### PR DESCRIPTION
(Relies on the later PRs for `__main__.py` to exist)

This sets up `spurt` when you install the package:

```
$ pip install -e .
...
$ spurt --help
usage: spurt.workflows.emcf [-h] [--version] [-i INPUTDIR] [-o OUTPUTDIR] [--tempdir TEMPDIR] [-w WORKERS] [-b BATCHSIZE] [-c COH] [--singletile]

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -i INPUTDIR, --inputdir INPUTDIR
                        Input folder with phase-linked SLC stack. (default: None)
  -o OUTPUTDIR, --outputdir OUTPUTDIR
                        Output folder for final unwrapped raster files. (default: ./emcf)
  --tempdir TEMPDIR     Folder for intermediate outputs. (default: ./emcf_tmp)
  -w WORKERS, --workers WORKERS
                        Number of workers. <=0 uses ncpus - 1. (default: 0)
  -b BATCHSIZE, --batchsize BATCHSIZE
                        Links per batch for temporal unwrapping. (default: 50000)
  -c COH, --coh COH     Temporal coherence threshold for good pixels. (default: 0.6)
  --singletile          Process as a single tile. (default: False)
```