### PR TITLE
`hop3.py`: Fix typo in `.boundary` of graph.

### DIFF
--- a/src/spurt/graph/_hop3.py
+++ b/src/spurt/graph/_hop3.py
@@ -49,7 +49,7 @@ class Hop3Graph(PlanarGraphInterface):
 
     @property
     def boundary(self) -> np.ndarray:
-        return np.ndarray([[0, 1], [1, 3], [3, 0]])
+        return np.array([[0, 1], [1, 3], [3, 0]])
 
     def _create_cycles_and_links(self) -> None:
         arcs: set[tuple[int, int]] = set()

--- a/test/graph/test_hop3.py
+++ b/test/graph/test_hop3.py
@@ -21,3 +21,5 @@ class TestHop3:
 
         # Euler's formula
         assert (g.npoints - len(g.links) + len(g.cycles) + 1) == 2
+
+        assert g.boundary == np.array([[0, 1], [1, 3], [3, 0]])


### PR DESCRIPTION
Using the boundary currently throws `TypeError: 'list' object cannot be interpreted as an integer`
(I couldn't add as a suggestion to one of the PRs since it was already merged). 