### PR TITLE
Fix out of order uw data from `as_completed` shuffling

### DIFF
--- a/src/spurt/workflows/emcf/_cli.py
+++ b/src/spurt/workflows/emcf/_cli.py
@@ -35,14 +35,13 @@ def main(args=None):
         "--tempdir", default="./emcf_tmp", help="Folder for intermediate outputs."
     )
     parser.add_argument(
-        "-tw",
+        "-w",
         "--t-workers",
         type=int,
         default=0,
         help="Number of workers for temporal unwrapping. <=0 uses ncpus - 1.",
     )
     parser.add_argument(
-        "-sw",
         "--s-workers",
         type=int,
         default=1,

--- a/src/spurt/workflows/emcf/_cli.py
+++ b/src/spurt/workflows/emcf/_cli.py
@@ -35,11 +35,18 @@ def main(args=None):
         "--tempdir", default="./emcf_tmp", help="Folder for intermediate outputs."
     )
     parser.add_argument(
-        "-w",
-        "--workers",
+        "-tw",
+        "--t-workers",
         type=int,
         default=0,
-        help="Number of workers. <=0 uses ncpus - 1.",
+        help="Number of workers for temporal unwrapping. <=0 uses ncpus - 1.",
+    )
+    parser.add_argument(
+        "-sw",
+        "--s-workers",
+        type=int,
+        default=1,
+        help="Number of workers for spatial unwrapping. <=0 uses ncpus - 1.",
     )
     parser.add_argument(
         "-b",
@@ -80,7 +87,8 @@ def main(args=None):
 
     # Create solver settings
     slv_settings = SolverSettings(
-        t_worker_count=parsed_args.workers,
+        t_worker_count=parsed_args.t_workers,
+        s_worker_count=parsed_args.s_workers,
         links_per_batch=parsed_args.batchsize,
     )
 

--- a/src/spurt/workflows/emcf/_solver.py
+++ b/src/spurt/workflows/emcf/_solver.py
@@ -261,8 +261,9 @@ class EMCFSolver:
                 )
                 for ii in range(self.nifgs)
             ]
-        for ii, fut in enumerate(as_completed(futures)):
-            uw_data[ii, :] = fut.result()
+        for fut in as_completed(futures):
+            ii, data = fut.result()
+            uw_data[ii, :] = data
         return uw_data
 
     def _ifg_spatial_gradients_from_slc(
@@ -316,4 +317,4 @@ def _unwrap_ifg_in_space(ifg_grad, solver_space, cost, ii):
     # Flood fill
     out = utils.flood_fill(ifg_grad, solver_space.edges, flows, mode="gradients")
     logger.info(f"Completed spatial unwrapping {ii + 1}")
-    return out
+    return ii, out


### PR DESCRIPTION
I had been still getting the `AssertionError: Arrays differ by non-integer cycles` problem when trying to tile. I tracked this when I wrote out each spatial unwrapping result to a numpy array within the future, it perfectly matched the spurt CLI. But then the HDF5 saved data was different.

The cause: `as_completed` returns data out of order (possibly). This leads to random row shuffling of `uw_data`.

Still not quite sure how doing the single worker didn't fix this when we checked earlier.


(Also: I missed adding separate options to the CLI in the last PR)