### PR TITLE
Remove maxtasksperchild

### DIFF
--- a/src/spurt/links/_grid_search.py
+++ b/src/spurt/links/_grid_search.py
@@ -150,9 +150,7 @@ class GridSearchLinearModel(Parameters, LinkModelInterface):
                     )
 
             # Create a pool and dispatch
-            with get_context("fork").Pool(
-                processes=worker_count, maxtasksperchild=1
-            ) as p:
+            with get_context("fork").Pool(processes=worker_count) as p:
                 mp_tasks = p.imap_unordered(wrap_solve, inv_inputs(range(nruns)))
 
                 # Gather results

--- a/src/spurt/mcf/_ortools.py
+++ b/src/spurt/mcf/_ortools.py
@@ -268,9 +268,7 @@ class ORMCFSolver(MCFSolverInterface):
             # Create a pool and dispatch
             # We explicitly use fork here as osx has switched to using spawn
             # and that really slows down the use of multiprocessing
-            with get_context("fork").Pool(
-                processes=worker_count, maxtasksperchild=1
-            ) as p:
+            with get_context("fork").Pool(processes=worker_count) as p:
                 mp_tasks = p.imap_unordered(wrap_solve_mcf, uw_inputs(range(nruns)))
 
                 # Gather results

--- a/src/spurt/workflows/emcf/_solver.py
+++ b/src/spurt/workflows/emcf/_solver.py
@@ -261,9 +261,9 @@ class EMCFSolver:
                 )
                 for ii in range(self.nifgs)
             ]
-        for fut in as_completed(futures):
-            ii, data = fut.result()
-            uw_data[ii, :] = data
+            for fut in as_completed(futures):
+                ii, data = fut.result()
+                uw_data[ii, :] = data
         return uw_data
 
     def _ifg_spatial_gradients_from_slc(


### PR DESCRIPTION
- Remnant from setup specific to spatial unwrapping only
- Should address #30 
- Number of workers tuning really depends on the env on which this will be deployed
- Includes a bug fix to spatial unwrapping parallelization