### PR TITLE
Adding ability to merge multiple interferograms in a batch

### DIFF
--- a/src/spurt/workflows/emcf/_cli.py
+++ b/src/spurt/workflows/emcf/_cli.py
@@ -51,7 +51,7 @@ def main(args=None):
         "-b",
         "--batchsize",
         type=int,
-        default=50000,
+        default=150000,
         help="Links per batch for temporal unwrapping.",
     )
     parser.add_argument(
@@ -60,6 +60,9 @@ def main(args=None):
         type=float,
         default=0.6,
         help="Temporal coherence threshold for good pixels.",
+    )
+    parser.add_argument(
+        "--pts-per-tile", type=int, default=800000, help="Target points per tile"
     )
     parser.add_argument(
         "--singletile", action="store_true", help="Process as a single tile."
@@ -82,7 +85,7 @@ def main(args=None):
     )
 
     # Create tile settings
-    tile_settings = TilerSettings()
+    tile_settings = TilerSettings(target_points_per_tile=parsed_args.pts_per_tile)
 
     # Create solver settings
     slv_settings = SolverSettings(

--- a/src/spurt/workflows/emcf/_cli.py
+++ b/src/spurt/workflows/emcf/_cli.py
@@ -62,7 +62,16 @@ def main(args=None):
         help="Temporal coherence threshold for good pixels.",
     )
     parser.add_argument(
-        "--pts-per-tile", type=int, default=800000, help="Target points per tile"
+        "--pts-per-tile",
+        type=int,
+        default=800000,
+        help="Target points per tile.",
+    )
+    parser.add_argument(
+        "--merge-parallel-ifgs",
+        type=int,
+        default=1,
+        help="Number of ifgs to merge in parallel.",
     )
     parser.add_argument(
         "--singletile", action="store_true", help="Process as a single tile."
@@ -95,7 +104,9 @@ def main(args=None):
     )
 
     # Create merger settings
-    mrg_settings = MergerSettings()
+    mrg_settings = MergerSettings(
+        num_parallel_ifgs=parsed_args.merge_parallel_ifgs,
+    )
 
     # Using default Hop3Graph
     logger.info(f"Using Hop3 Graph in time with {len(stack.slc_files)} epochs.")

--- a/src/spurt/workflows/emcf/_merge.py
+++ b/src/spurt/workflows/emcf/_merge.py
@@ -24,10 +24,6 @@ def merge_tiles(
         errmsg = "dirichlet is the only merge method supported."
         raise NotImplementedError(errmsg)
 
-    if mrg_settings.num_parallel_ifgs != 1:
-        errmsg = "This is a feature under development. Set num_parallel_ifgs=1."
-        raise NotImplementedError(errmsg)
-
     # Load tile json
     tiledata = spurt.utils.TileSet.from_json(gen_settings.tiles_jsonname)
 
@@ -79,7 +75,7 @@ def merge_tiles(
 
         # Process bstart to bend interferograms
         if batch_size > 1:
-            logger.info(f"Merging batch {bnum + 1} from {bstart + 1} to {bend + 1}")
+            logger.info(f"Merging batch {bnum + 1} from {bstart + 1} to {bend}")
 
         # Check if batch already processed
         idx = []

--- a/src/spurt/workflows/emcf/_merge.py
+++ b/src/spurt/workflows/emcf/_merge.py
@@ -157,20 +157,6 @@ def _adjust_tiles(
                 enable_logging=True,
             )
 
-            if False:
-                old_correction = np.zeros(raw_correction.shape, dtype=np.float32)
-
-                # Solve Dirichlet one-by-one
-                # scipy cg only supports on rhs at a time
-                for kk in range(correction.shape[0]):
-                    old_correction[kk, :] = spurt.utils.merge.dirichlet(
-                        tile_i.graph_laplacian,
-                        np.zeros(c.size),
-                        raw_correction[kk],
-                        c >= overlap_degree,
-                        enable_logging=True,
-                    )[0]
-
             tile_i.add_correction(correction)
 
         # Pop last element to keep corrections for using a lot of memory

--- a/src/spurt/workflows/emcf/_merge.py
+++ b/src/spurt/workflows/emcf/_merge.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+from numpy.linalg import norm as lpnorm
+from scipy.sparse import csc_matrix
+from scipy.sparse.linalg import LinearOperator, cg, spilu
 
 import spurt
 
@@ -149,17 +152,27 @@ def _adjust_tiles(
             raw_correction = overlap_average - data
 
             logger.info("Solving Dirichlet problem")
-            correction = np.zeros(raw_correction.shape, dtype=np.float32)
-            # Solve Dirichlet one-by-one
-            # scipy cg only supports on rhs at a time
-            for kk in range(correction.shape[0]):
-                correction[kk, :] = spurt.utils.merge.dirichlet(
+
+            if False:
+                correction = np.zeros(raw_correction.shape, dtype=np.float32)
+
+                # Solve Dirichlet one-by-one
+                # scipy cg only supports on rhs at a time
+                for kk in range(correction.shape[0]):
+                    correction[kk, :] = spurt.utils.merge.dirichlet(
+                        tile_i.graph_laplacian,
+                        np.zeros(c.size),
+                        raw_correction[kk],
+                        c >= overlap_degree,
+                        enable_logging=True,
+                    )[0]
+            else:
+                correction = _dirichlet_graph(
                     tile_i.graph_laplacian,
-                    np.zeros(c.size),
-                    raw_correction[kk],
+                    raw_correction,
                     c >= overlap_degree,
                     enable_logging=True,
-                )[0]
+                )
 
             tile_i.add_correction(correction)
 
@@ -234,3 +247,71 @@ def _get_max_degree(tiles: dict[int, Tile], shape: tuple[int, int]) -> int:
         count[coords[:, 0], coords[:, 1]] += 1
 
     return int(count.max())
+
+
+def _dirichlet_graph(
+    amat: csc_matrix,
+    xf: np.ndarray,
+    mask: np.ndarray,
+    maxiter: int | None = 100,
+    *,
+    enable_logging: bool = False,
+) -> np.ndarray:
+    """Specialized implementation of spurt.utils.merge.dirichlet.
+
+    Parameters
+    ----------
+    amat : array-like [m, m]
+        Square matrix.
+    xf : array-like [n, m]
+    Fixed data, only xf[:, mask] is significant as input.
+    mask : array-like[m] of bool
+    mask[i] is true if x[:, i] should be forced to equal xf[:, i]
+    enable_logging: bool
+        Optional, enable logger to capture diagnostic messages.
+
+    Returns
+    -------
+    x: array-like [n, m]
+    """
+    assert amat.shape[0] == amat.shape[1]
+    assert amat.shape[0] == xf.shape[1]
+
+    corrections = np.zeros(xf.shape, dtype=np.float32)
+    corrections[:, :] = xf[:, :]
+
+    # This part is from l2_min_cg
+    # We reuse the pre-conditioner here
+    mat = amat[:, ~mask][~mask, :].copy()
+    pre = spilu(mat, fill_factor=100)
+
+    for kk in range(xf.shape[0]):
+        b = -amat[:, mask].dot(xf[kk, mask])[~mask]
+
+        assert mat.shape[0] == b.shape[0]
+        if np.size(amat) == 0 and enable_logging:
+            logger.warning("A is empty; returning all zeros")
+            corrections[kk, ~mask] = 0
+            continue
+
+        if np.all(b == 0) and enable_logging:
+            logger.info("b is identically zero, returning zero.")
+            corrections[kk, ~mask] = 0
+            continue
+
+        x, info = cg(
+            mat,
+            b,
+            tol=1e-7,
+            atol=1e-7,
+            maxiter=maxiter,
+            M=LinearOperator(mat.shape, pre.solve),
+        )
+
+        r: np.ndarray = b - mat.dot(x)
+        if enable_logging and (maxiter is not None):
+            logger.info(f"Relative residual size {lpnorm(r, 2) / lpnorm(b, 2)}. ")
+
+        corrections[kk, ~mask] = x
+
+    return corrections

--- a/src/spurt/workflows/emcf/_merge.py
+++ b/src/spurt/workflows/emcf/_merge.py
@@ -24,6 +24,10 @@ def merge_tiles(
         errmsg = "dirichlet is the only merge method supported."
         raise NotImplementedError(errmsg)
 
+    if mrg_settings.num_parallel_ifgs != 1:
+        errmsg = "This is a feature under development. Set num_parallel_ifgs=1."
+        raise NotImplementedError(errmsg)
+
     # Load tile json
     tiledata = spurt.utils.TileSet.from_json(gen_settings.tiles_jsonname)
 

--- a/src/spurt/workflows/emcf/_settings.py
+++ b/src/spurt/workflows/emcf/_settings.py
@@ -170,11 +170,15 @@ class MergerSettings:
     bulk_method: str
         Method used to estimate bulk offset between tiles. Supported methods
         are 'integer' and 'L2'.
+    batch_size: int
+        Number of interferograms to merge in one batch. Use zero to merge all
+        interferograms in a single batch.
     """
 
     min_overlap_points: int = 25
     method: str = "dirichlet"
     bulk_method: str = "L2"
+    batch_size: int = 1
 
     def __post_init__(self):
         bulk_methods = {"integer", "L2"}

--- a/src/spurt/workflows/emcf/_settings.py
+++ b/src/spurt/workflows/emcf/_settings.py
@@ -38,7 +38,7 @@ class SolverSettings:
     """
 
     t_worker_count: int = 0
-    s_worker_count: int = 0
+    s_worker_count: int = 1
     links_per_batch: int = 10000
     t_cost_type: str = "constant"
     t_cost_scale: float = 100.0

--- a/src/spurt/workflows/emcf/_settings.py
+++ b/src/spurt/workflows/emcf/_settings.py
@@ -14,11 +14,12 @@ class SolverSettings:
     ----------
     t_worker_count: int
         Number of workers for temporal unwrapping in parallel. Set value to <=0
-        to let workflow use default workers (ncpus - 1).
+        to let workflow use default workers (ncpus - 1). Must be set when
+        num_parallel_tiles > 1.
     s_worker_count: int
         Number of workers for spatial unwrapping in parallel. Set value to <=0
-        to let workflow use (ncpus - 1).
-        Defaults to 1 (i.e. unwrap one interferogram in space at a time).
+        to let workflow use (ncpus - 1). Must be set when
+        num_parallel_tiles > 1.
     links_per_batch: int
         Temporal unwrapping operations over spatial links are performed in batches
         and each batch is solved in parallel.
@@ -37,7 +38,7 @@ class SolverSettings:
     """
 
     t_worker_count: int = 0
-    s_worker_count: int = 1
+    s_worker_count: int = 0
     links_per_batch: int = 10000
     t_cost_type: str = "constant"
     t_cost_scale: float = 100.0
@@ -62,6 +63,28 @@ class SolverSettings:
         if self.s_cost_scale <= 0.0:
             errmsg = f"s_cost_scale must be > 0, got {self.s_cost_scale}"
             raise ValueError(errmsg)
+
+        # num_parallel_tiles must be explicit - no system based defaults
+        if self.num_parallel_tiles < 1:
+            errmsg = f"num_parallel_tiles must be >= 1, got {self.num_parallel_tiles}"
+            raise ValueError(errmsg)
+
+        # if more than one tile being processed in parallel,
+        # worker counts must be set explicitly
+        if self.num_parallel_tiles > 1:
+            if self.t_worker_count < 1:
+                errmsg = (
+                    "t_worker_count must be explicitly set"
+                    " when processing tiles in parallel"
+                )
+                raise ValueError(errmsg)
+
+            if self.s_worker_count < 1:
+                errmsg = (
+                    "s_worker_count must be explicitly set"
+                    " when processing tiles in parallel"
+                )
+                raise ValueError(errmsg)
 
 
 @dataclass

--- a/src/spurt/workflows/emcf/_settings.py
+++ b/src/spurt/workflows/emcf/_settings.py
@@ -32,6 +32,8 @@ class SolverSettings:
         'centroid'.
     s_cost_scale: float
         Scale factor used in computing edge costs for spatial unwrapping.
+    num_parallel_tiles: int
+        Number of tiles to process in parallel. Set to 0 for all tiles.
     """
 
     t_worker_count: int = 0
@@ -41,6 +43,7 @@ class SolverSettings:
     t_cost_scale: float = 100.0
     s_cost_type: str = "constant"
     s_cost_scale: float = 100.0
+    num_parallel_tiles: int = 1
 
     def __post_init__(self):
         cost_types = {"constant", "distance", "centroid"}
@@ -170,7 +173,7 @@ class MergerSettings:
     bulk_method: str
         Method used to estimate bulk offset between tiles. Supported methods
         are 'integer' and 'L2'.
-    batch_size: int
+    num_parallel_ifgs: int
         Number of interferograms to merge in one batch. Use zero to merge all
         interferograms in a single batch.
     """
@@ -178,7 +181,7 @@ class MergerSettings:
     min_overlap_points: int = 25
     method: str = "dirichlet"
     bulk_method: str = "L2"
-    batch_size: int = 1
+    num_parallel_ifgs: int = 1
 
     def __post_init__(self):
         bulk_methods = {"integer", "L2"}

--- a/src/spurt/workflows/emcf/_solver.py
+++ b/src/spurt/workflows/emcf/_solver.py
@@ -9,7 +9,7 @@ import numpy as np
 from spurt.io import Irreg3DInput
 from spurt.links import LinkModelInterface
 from spurt.mcf import MCFSolverInterface, utils
-from spurt.utils import logger
+from spurt.utils import get_cpu_count, logger
 
 from ._settings import SolverSettings
 
@@ -250,7 +250,10 @@ class EMCFSolver:
         logger.info(f"Spatial: Number of links: {self.nlinks}")
         logger.info(f"Spatial: Number of cycles: {self._solver_space.ncycles}")
 
-        with ProcessPoolExecutor(max_workers=self.settings.s_worker_count) as executor:
+        nworkers = self.settings.s_worker_count
+        if nworkers < 1:
+            nworkers = get_cpu_count() - 1
+        with ProcessPoolExecutor(max_workers=nworkers) as executor:
             futures = [
                 executor.submit(
                     _unwrap_ifg_in_space,

--- a/src/spurt/workflows/emcf/_unwrap.py
+++ b/src/spurt/workflows/emcf/_unwrap.py
@@ -20,6 +20,10 @@ def unwrap_tiles(
     solv_settings: SolverSettings,
 ) -> None:
     """Unwrap each tile and save to h5."""
+    if solv_settings.num_parallel_tiles != 1:
+        errmsg = "This is a feature under development. Set num_parallel_tiles=1."
+        raise NotImplementedError(errmsg)
+
     # Temporal graph
     s_time = spurt.mcf.ORMCFSolver(g_time)  # type: ignore[abstract]
 

--- a/test/utils/test_dirichlet.py
+++ b/test/utils/test_dirichlet.py
@@ -29,9 +29,16 @@ def test_dirichlet():
     # Solve the Dirichlet problem.
     x, _ = spurt.utils.merge.dirichlet(lap, np.zeros(lap.shape[0]), pt_data, mask)
 
+    # Solve the Dirichlet graph
+    xg = spurt.utils.merge.dirichlet_graph(lap, np.expand_dims(pt_data, 0), mask)
+
     # x and pt_data should agree on the mask.
     assert np.all(x[mask] == pt_data[mask])
+    assert np.all(xg[0, mask] == pt_data[mask])
 
     # There should be no extrema outside the mask.
     assert np.max(x[mask]) <= np.max(pt_data[mask])
     assert np.min(x[mask]) >= np.min(pt_data[mask])
+
+    # Check that dirichlet_graph matches dirichlet
+    assert np.allclose(x, xg[0], atol=1.0e-4)

--- a/test/workflows/test_emcf.py
+++ b/test/workflows/test_emcf.py
@@ -113,7 +113,10 @@ def test_emcf_eq():
     s_space = spurt.mcf.ORMCFSolver(g_space)
 
     # Create EMCF solver
-    settings = spurt.workflows.emcf.SolverSettings()
+    settings = spurt.workflows.emcf.SolverSettings(
+        s_worker_count=1,
+        t_worker_count=1,
+    )
     solver = spurt.workflows.emcf.Solver(s_space, s_time, settings)
 
     w_data = spurt.io.Irreg3DInput(


### PR DESCRIPTION
- Reduces IO operations and increases memory footprint a bit
- `scipy` conjugate gradient also uses multiple threads by default which can be controlled with env variables related to `MKL`, `OpenBLAS` etc.
- This provides another parallelization option to improve performance
- `merge` step also depends on extent of overlap. Reducing the default tile dilation factor can help with speeding things up.