### PR TITLE
Adding tile parallelization during unwrapping

### DIFF
--- a/src/spurt/workflows/emcf/_cli.py
+++ b/src/spurt/workflows/emcf/_cli.py
@@ -74,6 +74,12 @@ def main(args=None):
         help="Number of ifgs to merge in parallel.",
     )
     parser.add_argument(
+        "--unwrap-parallel-tiles",
+        type=int,
+        default=1,
+        help="Number of tiles to unwrap in parallel.",
+    )
+    parser.add_argument(
         "--singletile", action="store_true", help="Process as a single tile."
     )
 
@@ -101,6 +107,7 @@ def main(args=None):
         t_worker_count=parsed_args.t_workers,
         s_worker_count=parsed_args.s_workers,
         links_per_batch=parsed_args.batchsize,
+        num_parallel_tiles=parsed_args.unwrap_parallel_tiles,
     )
 
     # Create merger settings

--- a/src/spurt/workflows/emcf/_unwrap.py
+++ b/src/spurt/workflows/emcf/_unwrap.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 import h5py
@@ -20,55 +21,85 @@ def unwrap_tiles(
     solv_settings: SolverSettings,
 ) -> None:
     """Unwrap each tile and save to h5."""
-    if solv_settings.num_parallel_tiles != 1:
-        errmsg = "This is a feature under development. Set num_parallel_tiles=1."
-        raise NotImplementedError(errmsg)
+    # Load tile set
+    tile_json = gen_settings.tiles_jsonname
+    tiledata = spurt.utils.TileSet.from_json(tile_json)
 
-    # Temporal graph
+    with ProcessPoolExecutor(max_workers=solv_settings.num_parallel_tiles) as executor:
+        futures = []
+
+        # Iterate over tiles
+        for tt in range(tiledata.ntiles):
+            tfname = str(gen_settings.tile_filename(tt))
+            if Path(tfname).is_file():
+                logger.info(f"Tile {tt+1} already processed. Skipping...")
+                continue
+
+            futures.append(
+                executor.submit(
+                    _unwrap_one_tile,
+                    stack,
+                    tile_json,
+                    tfname,
+                    g_time,
+                    solv_settings,
+                    tt,
+                )
+            )
+
+        for fut in as_completed(futures):
+            fut.result()
+
+
+def _unwrap_one_tile(
+    stack: spurt.io.SLCStackReader,
+    tile_json: Path,
+    tile_output: str,
+    g_time: spurt.graph.PlanarGraphInterface,
+    solv_settings: SolverSettings,
+    tile_num: int,
+) -> None:
+    """Unwrap tile-by-tile."""
+    # Get tile information
+    tiledata = spurt.utils.TileSet.from_json(tile_json)
+    tile = tiledata.tiles[tile_num]
+    tt = tile_num
+
+    # Temporal solver
     s_time = spurt.mcf.ORMCFSolver(g_time)  # type: ignore[abstract]
 
-    # Load tile set
-    tiledata = spurt.utils.TileSet.from_json(gen_settings.tiles_jsonname)
+    # Select valid pixels from coherence file
+    logger.info(f"Processing tile: {tt+1}")
+    coh = stack.read_temporal_coherence(tile.space)
 
-    # Iterate over tiles
-    for tt, tile in enumerate(tiledata.tiles):
-        tfname = str(gen_settings.tile_filename(tt))
-        if Path(tfname).is_file():
-            logger.info(f"Tile {tt+1} already processed. Skipping...")
-            continue
+    # Create spatial graph and solver
+    g_space = spurt.graph.DelaunayGraph(
+        np.column_stack(np.nonzero(coh > stack.temp_coh_threshold))
+    )
+    s_space = spurt.mcf.ORMCFSolver(g_space)  # type: ignore[abstract]
 
-        # Select valid pixels from coherence file
-        logger.info(f"Processing tile: {tt+1}")
-        coh = stack.read_temporal_coherence(tile.space)
+    # EMCF solver
+    solver = EMCFSolver(s_space, s_time, solv_settings)
+    wrap_data = stack.read_tile(tile.space)
+    assert wrap_data.shape[1] == g_space.npoints
+    logger.info(f"Time steps: {solver.nifgs}")
+    logger.info(f"Number of points: {solver.npoints}")
 
-        # Create spatial graph and solver
-        g_space = spurt.graph.DelaunayGraph(
-            np.column_stack(np.nonzero(coh > stack.temp_coh_threshold))
-        )
-        s_space = spurt.mcf.ORMCFSolver(g_space)  # type: ignore[abstract]
+    uw_data = solver.unwrap_cube(wrap_data)
+    logger.info(f"Completed tile: {tt+1}")
 
-        # EMCF solver
-        solver = EMCFSolver(s_space, s_time, solv_settings)
-        wrap_data = stack.read_tile(tile.space)
-        assert wrap_data.shape[1] == g_space.npoints
-        logger.info(f"Time steps: {solver.nifgs}")
-        logger.info(f"Number of points: {solver.npoints}")
+    # Unwrapped data above is always referenced to first pixel
+    # since we unwrap gradients. Phase offsets for the first
+    # pixel are computed and provided separately. When mosaicking,
+    # these offsets need to be added to unwrapped tiles to guarantee
+    # integer cycle shifts between tiles.
+    ifgs = g_time.links
+    phase_offset = spurt.mcf.utils.phase_diff(
+        wrap_data.data[ifgs[:, 0], 0], wrap_data.data[ifgs[:, 1], 0]
+    )
 
-        uw_data = solver.unwrap_cube(wrap_data)
-        logger.info(f"Completed tile: {tt+1}")
-
-        # Unwrapped data above is always referenced to first pixel
-        # since we unwrap gradients. Phase offsets for the first
-        # pixel are computed and provided separately. When mosaicking,
-        # these offsets need to be added to unwrapped tiles to guarantee
-        # integer cycle shifts between tiles.
-        ifgs = g_time.links
-        phase_offset = spurt.mcf.utils.phase_diff(
-            wrap_data.data[ifgs[:, 0], 0], wrap_data.data[ifgs[:, 1], 0]
-        )
-
-        _dump_tile_to_h5(tfname, uw_data, phase_offset, g_space, tile)
-        logger.info(f"Wrote tile {tt + 1} to {tfname}")
+    _dump_tile_to_h5(tile_output, uw_data, phase_offset, g_space, tile)
+    logger.info(f"Wrote tile {tt + 1} to {tile_output}")
 
 
 def _dump_tile_to_h5(


### PR DESCRIPTION
- Tiles can now be unwrapped in parallel now
- Uses simple `ProcessPoolExecutor` for parallelization
- For Hawaii dataset, unwraps in `~2 mins` with the following command:

`python3 -m spurt.workflows.emcf -i $SPURT_DIR/hawaii/interferograms --s-workers 3 --t-workers 1 -b 150000 --merge-parallel-ifgs 20 --pts-per-tile 80000 --unwrap-parallel-tiles 4`