### PR TITLE
Add `cd` workflow for uploading new releases to PyPI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,37 @@
+# This workflow will build a Python Package and upload to pypi. See:
+# https://docs.pypi.org/trusted-publishers/using-a-publisher/
+# https://github.com/marketplace/actions/pypi-publish
+name: CD
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      # retrieve your distributions here
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install build dependencies and package
+      run: |
+        python -m pip install --upgrade pip setuptools_scm
+        pip install build
+    - name: Get version and Build
+      run: |
+        # Version added upon installing package
+        python -m pip install --no-deps .
+        python -m build --sdist --wheel
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
When a release is made, the continuous deployment action will upload it to pypi. 

I can add you all to the pypi list of maintainers- it is currently pending
<img width="856" alt="image" src="https://github.com/user-attachments/assets/173a2280-ad23-4391-b94c-72c9ab18607d">
