### PR TITLE
Use `spawn` for all multiprocessing

### DIFF
--- a/src/spurt/mcf/_ortools.py
+++ b/src/spurt/mcf/_ortools.py
@@ -266,10 +266,10 @@ class ORMCFSolver(MCFSolverInterface):
                     )
 
             # Create a pool and dispatch
-            # We explicitly use fork here as osx has switched to using spawn
-            # and that really slows down the use of multiprocessing
-            with get_context("fork").Pool(processes=worker_count) as p:
-                mp_tasks = p.imap_unordered(wrap_solve_mcf, uw_inputs(range(nruns)))
+            with get_context("spawn").Pool(processes=worker_count) as p:
+                mp_tasks = p.imap_unordered(
+                    wrap_solve_mcf, uw_inputs(range(nruns)), chunksize=10_000
+                )
 
                 # Gather results
                 for res in mp_tasks:

--- a/src/spurt/workflows/emcf/_solver.py
+++ b/src/spurt/workflows/emcf/_solver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import multiprocessing
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import numpy as np
@@ -253,7 +254,8 @@ class EMCFSolver:
         nworkers = self.settings.s_worker_count
         if nworkers < 1:
             nworkers = get_cpu_count() - 1
-        with ProcessPoolExecutor(max_workers=nworkers) as executor:
+        ctx = multiprocessing.get_context("spawn")
+        with ProcessPoolExecutor(max_workers=nworkers, mp_context=ctx) as executor:
             futures = [
                 executor.submit(
                     _unwrap_ifg_in_space,

--- a/src/spurt/workflows/emcf/_unwrap.py
+++ b/src/spurt/workflows/emcf/_unwrap.py
@@ -1,3 +1,4 @@
+import multiprocessing
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
@@ -25,7 +26,10 @@ def unwrap_tiles(
     tile_json = gen_settings.tiles_jsonname
     tiledata = spurt.utils.TileSet.from_json(tile_json)
 
-    with ProcessPoolExecutor(max_workers=solv_settings.num_parallel_tiles) as executor:
+    mp_context = multiprocessing.get_context("spawn")
+    with ProcessPoolExecutor(
+        max_workers=solv_settings.num_parallel_tiles, mp_context=mp_context
+    ) as executor:
         futures = []
 
         # Iterate over tiles


### PR DESCRIPTION
I'll try and test this more, but I realized that in `dolphin`'s CI, I hadn't installed `spurt` to run the optional tests. Once I did, it [started hanging indefinitely](https://github.com/isce-framework/dolphin/pull/447) for anything larger than like 20x20 pixels. I think the reason is some bad combination of the libraries which use threads in earlier tests (see [here for long discussion](https://discuss.python.org/t/switching-default-multiprocessing-context-to-spawn-on-posix-as-well/21868/3)).

When I ran the [tests with this branch](https://github.com/isce-framework/dolphin/pull/447/commits/34d33abd43aa7572d20d53681f7f17e646f2fdb0), the went normally.

TODO: check that this doesn't make the temporal unwrapping part very slow.