### PR TITLE
Remove deprecated `tol` arguments from `cg` calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "numpy>=1.23",
   "ortools==9.8.3296",
   "rasterio>=1.2",
-  "scipy>=1.9",
+  "scipy>=1.12",
 ]
 dynamic = ["version"]
 

--- a/src/spurt/utils/merge.py
+++ b/src/spurt/utils/merge.py
@@ -196,7 +196,7 @@ def l2_min_cg(
     x, info = cg(
         mat,
         rhs,
-        tol=1e-7,
+        rtol=1e-7,
         atol=1e-7,
         x0=x0,
         maxiter=maxiter,
@@ -345,7 +345,7 @@ def dirichlet_graph(
         x, info = cg(
             mat,
             b,
-            tol=1e-7,
+            rtol=1e-7,
             atol=1e-7,
             maxiter=maxiter,
             M=LinearOperator(mat.shape, pre.solve),


### PR DESCRIPTION
Scipy 1.13 was the last version this is allowed, and it is removed in 1.14: https://docs.scipy.org/doc/scipy-1.13.0/reference/generated/scipy.sparse.linalg.cg.html