### PR TITLE
Reduce memory usage with futures

### DIFF
--- a/scripts/plot_tiler.py
+++ b/scripts/plot_tiler.py
@@ -1,0 +1,33 @@
+import json
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
+
+if __name__ == "__main__":
+    jname = sys.argv[1]
+    with Path(jname).open(mode="r") as fid:
+        data = json.load(fid)
+
+    shape = data["shape"]
+
+    fig, ax = plt.subplots(1, 1, figsize=(7, 7))
+    ax.set_ylim(0, shape[0])
+    ax.set_xlim(0, shape[1])
+    sum_diag = 0
+    sum_diag2 = 0
+    for tile in data["tiles"]:
+        p = tile["bounds"]
+        ax.add_patch(
+            Rectangle(
+                (p[1], p[0]),
+                p[3] - p[1],
+                p[2] - p[0],
+                facecolor="none",
+                linewidth=1,
+                edgecolor="k",
+            )
+        )
+
+    plt.show()

--- a/src/spurt/mcf/_interface.py
+++ b/src/spurt/mcf/_interface.py
@@ -187,6 +187,7 @@ class MCFSolverInterface(Protocol):
         cost: ArrayLike,
         revcost: ArrayLike | None = None,
         worker_count: int | None = None,
+        chunksize: int | None = 1,
     ) -> ArrayLike:
         """Solver should return integer flows corresponding to given residues.
 

--- a/src/spurt/mcf/_ortools.py
+++ b/src/spurt/mcf/_ortools.py
@@ -219,6 +219,7 @@ class ORMCFSolver(MCFSolverInterface):
         cost: np.ndarray,
         revcost: np.ndarray | None = None,
         worker_count: int | None = None,
+        chunksize: int | None = 1,
     ) -> np.ndarray:
         """Parallel version of residues_to_flows.
 
@@ -273,7 +274,9 @@ class ORMCFSolver(MCFSolverInterface):
             # We explicitly use fork here as osx has switched to using spawn
             # and that really slows down the use of multiprocessing
             with get_context("fork").Pool(processes=worker_count) as p:
-                mp_tasks = p.imap_unordered(wrap_solve_mcf, uw_inputs(range(nruns)))
+                mp_tasks = p.imap_unordered(
+                    wrap_solve_mcf, uw_inputs(range(nruns)), chunksize=chunksize
+                )
 
                 # Gather results
                 for res in mp_tasks:

--- a/src/spurt/workflows/emcf/_solver.py
+++ b/src/spurt/workflows/emcf/_solver.py
@@ -214,7 +214,10 @@ class EMCFSolver:
             # Unwrap the batch
             logger.info(f"Temporal: Unwrapping batch {bb + 1}/{nbatches}")
             flows = self._solver_time.residues_to_flows_many(
-                residues, cost, worker_count=self.settings.t_worker_count
+                residues,
+                cost,
+                worker_count=self.settings.t_worker_count,
+                chunksize=50000,
             )
 
             # Update the spatial gradients with estimated flows


### PR DESCRIPTION
* Use dict and pop results from `ProcessPoolExecutor` futures
* Use `fork` explicitly with `ProcessPoolExecutor`