### PR TITLE
Add `__future__.annotations` imports to remaining modules to fix Python 3.9 support

### DIFF
--- a/src/spurt/graph/_delaunay.py
+++ b/src/spurt/graph/_delaunay.py
@@ -1,5 +1,7 @@
 """Delaunay triangulation specific graph."""
 
+from __future__ import annotations
+
 import numpy as np
 from numpy.typing import ArrayLike
 from scipy.spatial import Delaunay

--- a/src/spurt/graph/_hop3.py
+++ b/src/spurt/graph/_hop3.py
@@ -1,5 +1,7 @@
 """Build hop-3 planar graphs."""
 
+from __future__ import annotations
+
 import numpy as np
 
 from ._interface import PlanarGraphInterface

--- a/src/spurt/links/_common.py
+++ b/src/spurt/links/_common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from scipy.sparse import csc_matrix, csr_matrix
 

--- a/src/spurt/utils/merge.py
+++ b/src/spurt/utils/merge.py
@@ -1,5 +1,7 @@
 """Utilities for merging point clouds."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np

--- a/src/spurt/workflows/emcf/_output.py
+++ b/src/spurt/workflows/emcf/_output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 import os
 from pathlib import Path


### PR DESCRIPTION
Just added some min-python version tests and saw 
```python-traceback
  File "/Users/staniewi/miniconda3/envs/dolphin-39/lib/python3.9/site-packages/spurt/utils/merge.py", line 92, in <module>
    amat: np.ndarray | csr_matrix | csc_matrix,
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```