### PR TITLE
Change pin of `ortools` to lower bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.9"
 dependencies = [
   "h5py>=3.6",
   "numpy>=1.23",
-  "ortools==9.8.3296",
+  "ortools>=9.8.3296",
   "rasterio>=1.2",
   "scipy>=1.12",
 ]


### PR DESCRIPTION
This version of `ortools` doesn't work with Python 3.12+.