### PR TITLE
Adding support for non-overlapping tiles

### DIFF
--- a/src/spurt/workflows/emcf/_merge.py
+++ b/src/spurt/workflows/emcf/_merge.py
@@ -95,11 +95,18 @@ def merge_tiles(
         # Initialize each tile for the right band with bulk offset
         for jj, tile in tiles.items():
             tile.reset_band_index(idx)
-            tile.add_correction(np.float32(-2 * np.pi * bulk_offsets[idx, jj]))
+            if bulk_offsets:
+                tile.add_correction(np.float32(-2 * np.pi * bulk_offsets[idx, jj]))
+            else:
+                # This is to set tile metadata
+                tile.add_correction(np.float32(0.0))
             tile.increment_correction()
 
-        # Adjust the tiles
-        _adjust_tiles(tiles, overlap_map, gen_settings, max_degree, debug_stats=False)
+        if bulk_offsets:
+            # Adjust the tiles
+            _adjust_tiles(
+                tiles, overlap_map, gen_settings, max_degree, debug_stats=False
+            )
 
         # Write file to output band-by-band
         for ii in idx:


### PR DESCRIPTION
Addressing the specific use case of island groups where we end up unrealistic looking Delaunay triangulations.
The easiest way to override the tile generation is to drop in a custom tile `tiles.json` file with each island is in its own tile.
The merge process just reassembles the unwrapped tiles and does not put attempt to resolve cycles between the islands.

Down stream impacts:
- It will be possible to improve time-series by doing inversion of each unwrapped tile with its own reference point.
- Each tile can directly be labelled as its own unwrapped component.